### PR TITLE
fix: unify inconsistent messages key

### DIFF
--- a/src/helpers/responseHandlers.js
+++ b/src/helpers/responseHandlers.js
@@ -18,6 +18,7 @@ module.exports = {
   }) => {
     res.status(statusCode).send({
       errMsg,
+      msg: err instanceof Error ? err.message : err.msg || err,
       message: err instanceof Error ? err.message : err.msg || err
     })
   },
@@ -31,6 +32,7 @@ module.exports = {
   }) => {
     res.status(statusCode).send({
       error: true,
+      msg: err instanceof Error ? err.message : errMsg || err,
       message: err instanceof Error ? err.message : errMsg || err
     })
   },

--- a/src/helpers/responseHandlers.js
+++ b/src/helpers/responseHandlers.js
@@ -18,7 +18,7 @@ module.exports = {
   }) => {
     res.status(statusCode).send({
       errMsg,
-      msg: err instanceof Error ? err.message : err.msg || err
+      message: err instanceof Error ? err.message : err.msg || err
     })
   },
 
@@ -31,7 +31,7 @@ module.exports = {
   }) => {
     res.status(statusCode).send({
       error: true,
-      msg: err instanceof Error ? err.message : errMsg || err
+      message: err instanceof Error ? err.message : errMsg || err
     })
   },
 


### PR DESCRIPTION
for some errors it returns `msg` and for some `message`