### PR TITLE
Potential fix for code scanning alert no. 1: Type confusion through parameter tampering

### DIFF
--- a/src/middleware/validateParams.js
+++ b/src/middleware/validateParams.js
@@ -123,12 +123,14 @@ export default {
         })
       }
 
-      // burn tx hash and event signature starts with 0x and their lengths must be equal to 66
+      // burn tx hash and event signature must be strings, start with 0x, and have length 66
       if (
+        typeof burnTxHash !== 'string' ||
+        typeof eventSignature !== 'string' ||
         !burnTxHash.startsWith('0x') ||
-                !eventSignature.startsWith('0x') ||
-                burnTxHash.length !== 66 ||
-                eventSignature.length !== 66
+        !eventSignature.startsWith('0x') ||
+        burnTxHash.length !== 66 ||
+        eventSignature.length !== 66
       ) {
         return handleBadRequest({
           res,


### PR DESCRIPTION
Potential fix for [https://github.com/0xPolygon/proof-generation-api/security/code-scanning/1](https://github.com/0xPolygon/proof-generation-api/security/code-scanning/1)

To fix the problem, we need to ensure that the parameters being validated are strings. This can be done by adding a runtime type check that verifies each parameter is of type "string" before applying string methods or length checks. If the value is not a string, this should be flagged as an invalid request and handled accordingly. We should update the checks in `validateExitPayloadParams` to verify both `burnTxHash` and `eventSignature` are strings before running `.startsWith()` and `.length` on them. This fix should be applied directly in the sanitizer block, and should not change functional behavior for valid requests.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
